### PR TITLE
Fix #124 - Add support for zio environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -458,6 +458,7 @@ project/plugins/project/
 .metals/
 .bloop/
 project/secret
+project/metals.sbt
 
 # mdoc
 website/node_modules

--- a/docs/overview/basics.md
+++ b/docs/overview/basics.md
@@ -23,6 +23,7 @@ import java.io.File
 import zio.actors.Actor.Stateful
 import zio.actors._
 import zio.IO
+import zio.ZIO
 ```
 
 Our domain that will be used:
@@ -35,8 +36,8 @@ case class DoubleCommand(value: Int) extends Command[Int]
 Our actor's assigment will be to double received values. Here's the `Stateful` implementation:
 
 ```scala mdoc:silent
-val stateful = new Stateful[Unit, Throwable, Command] {
-  override def receive[A](state: Unit, msg: Command[A], context: Context): IO[Throwable, (Unit, A)] =
+val stateful = new Stateful[Any, Unit, Throwable, Command] {
+  override def receive[A](state: Unit, msg: Command[A], context: Context): ZIO[Any, Throwable, (Unit, A)] =
     msg match {
       case DoubleCommand(value) => IO.effectTotal(((), value * 2))
     }

--- a/docs/overview/supervision.md
+++ b/docs/overview/supervision.md
@@ -33,5 +33,5 @@ Supervisor.retry(Schedule.recurs(10))
 The general method also requires effect that will be executed on `Schedule` end:
 
 ```scala mdoc:silent
-Supervisor.retryOrElse[Exception, Int](Schedule.recurs(10), (e, a) => putStrLn("nothing can be done").provide(Console.Live))
+Supervisor.retryOrElse[Any, Exception, Int](Schedule.recurs(10), (e, a) => putStrLn("nothing can be done").provide(Console.Live))
 ```

--- a/docs/usecases/pingpong.md
+++ b/docs/usecases/pingpong.md
@@ -32,7 +32,7 @@ case class Ping(sender: ActorRef[Throwable, PingPong])        extends PingPong[U
 case object Pong                                              extends PingPong[Unit]
 case class GameInit(recipient: ActorRef[Throwable, PingPong]) extends PingPong[Unit]
 
-val protoHandler = new Stateful[Unit, Throwable, PingPong] {
+val protoHandler = new Stateful[Any, Unit, Throwable, PingPong] {
     override def receive[A](
       state: Unit,
       msg: PingPong[A],

--- a/src/main/scala/zio/actors/Supervisor.scala
+++ b/src/main/scala/zio/actors/Supervisor.scala
@@ -2,26 +2,28 @@ package zio.actors
 
 import zio.{ IO, Schedule, ZIO }
 
-private[actors] trait Supervisor[-E] {
-  def supervise[A](io: IO[E, A], error: E): IO[Unit, A]
+private[actors] trait Supervisor[-R, -E] {
+  def supervise[R0 <: R, A](zio: ZIO[R0, E, A], error: E): ZIO[R0, Unit, A]
 }
 
 /**
  *  Supervising policies
  */
 object Supervisor {
-  final def none: Supervisor[Any] = retry(Schedule.once)
 
-  final def retry[E, A](policy: Schedule[Any, E, A]): Supervisor[E] =
+  final def none: Supervisor[Any, Any] = retry(Schedule.once)
+
+  final def retry[R, E, A](policy: Schedule[R, E, A]): Supervisor[R, E] =
     retryOrElse(policy, (_: E, _: A) => IO.unit)
 
-  final def retryOrElse[E, A](
-    policy: Schedule[Any, E, A],
-    orElse: (E, A) => IO[E, Unit]
-  ): Supervisor[E] =
-    new Supervisor[E] {
-      override def supervise[A0](io: IO[E, A0], error: E): IO[Unit, A0] =
-        io.retryOrElse(policy, (e: E, a: A) => orElse(e, a) *> ZIO.fail(error))
+  final def retryOrElse[R, E, A](
+    policy: Schedule[R, E, A],
+    orElse: (E, A) => ZIO[R, E, Unit]
+  ): Supervisor[R, E] =
+    new Supervisor[R, E] {
+      override def supervise[R0 <: R, A0](zio: ZIO[R0, E, A0], error: E): ZIO[R0, Unit, A0] =
+        zio
+          .retryOrElse(policy, (e: E, a: A) => orElse(e, a) *> ZIO.fail(error))
           .mapError(_ => ())
     }
 }

--- a/src/test/scala/zio/actors/ActorsSpec.scala
+++ b/src/test/scala/zio/actors/ActorsSpec.scala
@@ -31,7 +31,7 @@ object ActorsSpec
         testM("sequential message processing") {
           import CounterUtils._
 
-          val handler = new Stateful[Int, Nothing, Message] {
+          val handler = new Stateful[Any, Int, Nothing, Message] {
             override def receive[A](
               state: Int,
               msg: Message[A],
@@ -59,8 +59,8 @@ object ActorsSpec
 
           val maxRetries = 10
 
-          def makeHandler(ref: Ref[Int]): Actor.Stateful[Unit, Throwable, Message] =
-            new Stateful[Unit, Throwable, Message] {
+          def makeHandler(ref: Ref[Int]): Actor.Stateful[Any, Unit, Throwable, Message] =
+            new Stateful[Any, Unit, Throwable, Message] {
               override def receive[A](
                 state: Unit,
                 msg: Message[A],
@@ -91,7 +91,7 @@ object ActorsSpec
         testM("error recovery by fallback action") {
           import TickUtils._
 
-          val handler = new Stateful[Unit, Throwable, Message] {
+          val handler = new Stateful[Any, Unit, Throwable, Message] {
             override def receive[A](
               state: Unit,
               msg: Message[A],
@@ -105,7 +105,7 @@ object ActorsSpec
           val called   = new AtomicBoolean(false)
           val schedule = Schedule.recurs(10)
           val policy =
-            Supervisor.retryOrElse[Throwable, Int](
+            Supervisor.retryOrElse[Any, Throwable, Int](
               schedule,
               (_, _) => IO.effectTotal(called.set(true))
             )
@@ -121,7 +121,7 @@ object ActorsSpec
         testM("Stopping actors") {
           import StopUtils._
 
-          val handler = new Stateful[Unit, Throwable, Msg] {
+          val handler = new Stateful[Any, Unit, Throwable, Msg] {
             override def receive[A](
               state: Unit,
               msg: Msg[A],

--- a/src/test/scala/zio/actors/RemoteSpec.scala
+++ b/src/test/scala/zio/actors/RemoteSpec.scala
@@ -20,7 +20,7 @@ object SpecUtils {
   sealed trait MyErrorDomain extends Throwable
   case object DomainError    extends MyErrorDomain
 
-  val handlerMessageTrait = new Stateful[Int, MyErrorDomain, Message] {
+  val handlerMessageTrait = new Stateful[Any, Int, MyErrorDomain, Message] {
     override def receive[A](
       state: Int,
       msg: Message[A],
@@ -37,7 +37,7 @@ object SpecUtils {
   case object Pong                                                   extends PingPongProto[Unit]
   case class GameInit(recipient: ActorRef[Throwable, PingPongProto]) extends PingPongProto[Unit]
 
-  val protoHandler = new Stateful[Unit, Throwable, PingPongProto] {
+  val protoHandler = new Stateful[Any, Unit, Throwable, PingPongProto] {
     override def receive[A](
       state: Unit,
       msg: PingPongProto[A],
@@ -69,7 +69,7 @@ object SpecUtils {
   sealed trait ErrorProto[+A]
   case object UnsafeMessage extends ErrorProto[String]
 
-  val errorHandler = new Stateful[Unit, Throwable, ErrorProto] {
+  val errorHandler = new Stateful[Any, Unit, Throwable, ErrorProto] {
     override def receive[A](
       state: Unit,
       msg: ErrorProto[A],


### PR DESCRIPTION
Modified Supervisor in order to accept an R as environment and changed Supervisor::retryOrElse to support that.

Also ignored files related to Metals configuration.

This resolves #124 