### PR TITLE
Add gpg2 support to circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,16 @@ release: &release
           command: echo -n "${PGP_SECRET}" | base64 -di > /tmp/secret.asc
       - run:
           name: Release artifacts
-          command: ./sbt ++${SCALA_VERSION}! clean ci-release
+          command: |
+            sudo apt-get update && sudo apt-get -y install gnupg2
+            echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
+            echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
+            chmod 600 ~/.gnupg/*
+            echo RELOADAGENT | gpg-connect-agent
+            echo $PGP_SECRET | base64 -di | gpg --import --no-tty --batch --yes
+            mkdir -p $HOME/bin
+            ln -s /usr/bin/gpg2 $HOME/bin/gpg
+            PATH=$HOME/bin:$PATH ./sbt ++${SCALA_VERSION}! clean ci-release
 
 microsite: &microsite
   steps:


### PR DESCRIPTION
# Summary
- Fix for doing PGP signed releases.
- Once I merge going to do a release to test. 
- Already done a manual test with success.