### PR TITLE
Fixed #131 - Validate actorName in make method

### DIFF
--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -40,3 +40,11 @@ testSystem62.zio.actors.remoting {
   hostname = ${HOST}
   port     = 9676
 }
+testSystem71.zio.actors.remoting {
+  hostname = ${HOST}
+  port     = 9677
+}
+testSystem72.zio.actors.remoting {
+  hostname = ${HOST}
+  port     = 9678
+}


### PR DESCRIPTION
Resolves #131

This PR improves actor name validation when an actor is created or selected.
The name is validated with :
 * regex that allows some special characters -_. * $ +: @ & =,! ~ ';
 * Not null name
 * Non Empty  name 
Also in the selection of nested actors (actorOne / childOne), the route is validated correctly.