### PR TITLE
Examples module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val root =
   project
     .in(file("."))
     .settings(skip in publish := true)
-    .aggregate(zioActors, zioActorsPersistence, zioActorsPersistenceJDBC)
+    .aggregate(zioActors, zioActorsPersistence, zioActorsPersistenceJDBC, examples)
 
 lazy val zioActors = module("zio-actors", "actors")
   .enablePlugins(BuildInfoPlugin)
@@ -79,9 +79,21 @@ lazy val zioActorsPersistenceJDBC = module("zio-actors-persistence-jdbc", "persi
       "org.tpolecat" %% "doobie-hikari"    % "0.8.8",
       "org.tpolecat" %% "doobie-postgres"  % "0.8.8"
     ),
-    testFrameworks := Seq(new TestFramework(""))
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
   )
   .dependsOn(zioActorsPersistence)
+
+lazy val examples = module("zio-actors-examples", "examples")
+  .settings(
+    skip in publish := true,
+    fork := true,
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-test"     % zioVersion % "test",
+      "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
+    ),
+    testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
+  )
+  .dependsOn(zioActors, zioActorsPersistence, zioActorsPersistenceJDBC)
 
 def module(moduleName: String, fileName: String): Project =
   Project(moduleName, file(fileName))

--- a/docs/usecases/index.md
+++ b/docs/usecases/index.md
@@ -6,3 +6,6 @@ title: "Contents"
 So now how to use it? Here you can find some examples to dive into:
 
  - **[Ping Pong](pingpong.md)** — Example of `fire-and-forget` ping-pong with remote actor lookup
+
+Also there are project samples in `examples` root directory of the repo.
+They are meant to be a counterpart of [akka-samples](https://github.com/akka/akka-samples) for `zio-actors`.

--- a/examples/src/main/scala/zio/actors/examples/persistence/ShoppingCart.scala
+++ b/examples/src/main/scala/zio/actors/examples/persistence/ShoppingCart.scala
@@ -1,0 +1,153 @@
+package zio.actors.examples.persistence
+
+import java.time.Instant
+
+import zio.UIO
+import zio.actors.persistence.PersistenceId.PersistenceId
+import zio.actors.{ persistence, Context }
+import zio.actors.persistence._
+
+/**
+ *
+ * This is a full example of [[https://github.com/akka/akka-samples/tree/2.6/akka-sample-persistence-scala Akka persistence shopping cart]]
+ * rewritten in ZIO-Actors together with tests.
+ *
+ */
+object ShoppingCart {
+
+  final case class State(items: Map[String, Int], checkoutDate: Option[Instant]) {
+
+    def isCheckedOut: Boolean =
+      checkoutDate.isDefined
+
+    def hasItem(itemId: String): Boolean =
+      items.contains(itemId)
+
+    def isEmpty: Boolean =
+      items.isEmpty
+
+    def updateItem(itemId: String, quantity: Int): State =
+      quantity match {
+        case 0 => copy(items = items - itemId)
+        case _ => copy(items = items + (itemId -> quantity))
+      }
+
+    def removeItem(itemId: String): State =
+      copy(items = items - itemId)
+
+    def checkout(now: Instant): State =
+      copy(checkoutDate = Some(now))
+
+    def toSummary: Summary =
+      Summary(items, isCheckedOut)
+  }
+  object State {
+    val empty = State(items = Map.empty, checkoutDate = None)
+  }
+
+  sealed trait Command[+_]
+  final case class AddItem(itemId: String, quantity: Int)            extends Command[Confirmation]
+  final case class RemoveItem(itemId: String)                        extends Command[Confirmation]
+  final case class AdjustItemQuantity(itemId: String, quantity: Int) extends Command[Confirmation]
+  final case object Checkout                                         extends Command[Confirmation]
+  final case object Get                                              extends Command[Summary]
+
+  final case class Summary(items: Map[String, Int], checkedOut: Boolean)
+
+  sealed trait Confirmation
+  final case class Accepted(summary: Summary) extends Confirmation
+  final case class Rejected(reason: String)   extends Confirmation
+
+  sealed trait Event {
+    def cartId: String
+  }
+
+  final case class ItemAdded(cartId: String, itemId: String, quantity: Int)               extends Event
+  final case class ItemRemoved(cartId: String, itemId: String)                            extends Event
+  final case class ItemQuantityAdjusted(cartId: String, itemId: String, newQuantity: Int) extends Event
+  final case class CheckedOut(cartId: String, eventTime: Instant)                         extends Event
+
+  def apply(cartId: String): EventSourcedStateful[Any, State, Command, Event] =
+    new EventSourcedStateful[Any, State, Command, Event](PersistenceId(cartId)) {
+      override def receive[A](
+        state: State,
+        msg: Command[A],
+        context: Context
+      ): UIO[(persistence.Command[Event], State => A)] =
+        if (state.isCheckedOut) checkedOutShoppingCart[A](cartId, state, msg)
+        else openShoppingCard[A](cartId, state, msg)
+
+      override def sourceEvent(state: State, event: Event): State =
+        event match {
+          case ItemAdded(_, itemId, quantity) => state.updateItem(itemId, quantity)
+          case ItemRemoved(_, itemId)         => state.removeItem(itemId)
+          case ItemQuantityAdjusted(_, itemId, quantity) =>
+            state.updateItem(itemId, quantity)
+          case CheckedOut(_, eventTime) => state.checkout(eventTime)
+        }
+    }
+
+  private def openShoppingCard[A](
+    cartId: String,
+    state: State,
+    command: Command[A]
+  ): UIO[(persistence.Command[Event], State => A)] =
+    command match {
+      case AddItem(itemId, quantity) =>
+        if (state.hasItem(itemId)) {
+          UIO((Command.ignore, _ => Rejected(s"Item '$itemId' was already added to this shopping cart")))
+        } else if (quantity <= 0) {
+          UIO((Command.ignore, _ => Rejected("Quantity must be greater than zero")))
+        } else {
+          UIO((Command.persist(ItemAdded(cartId, itemId, quantity)), updatedState => Accepted(updatedState.toSummary)))
+        }
+      case RemoveItem(itemId) =>
+        if (state.hasItem(itemId)) {
+          UIO((Command.persist(ItemRemoved(cartId, itemId)), updatedState => Accepted(updatedState.toSummary)))
+        } else {
+          UIO((Command.ignore, _ => Accepted(state.toSummary)))
+        }
+      case AdjustItemQuantity(itemId, quantity) =>
+        if (quantity <= 0) {
+          UIO((Command.ignore, _ => Rejected("Quantity must be greater than zero")))
+        } else if (state.hasItem(itemId)) {
+          UIO(
+            (
+              Command.persist(ItemQuantityAdjusted(cartId, itemId, quantity)),
+              updatedCart => Accepted(updatedCart.toSummary)
+            )
+          )
+        } else {
+          UIO((Command.ignore, _ => Rejected(s"Cannot adjust quantity for item '$itemId'. Item not present on cart")))
+        }
+
+      case Checkout =>
+        if (state.isEmpty) {
+          UIO((Command.ignore, _ => Rejected("Cannot checkout an empty shopping cart")))
+        } else {
+          UIO((Command.persist(CheckedOut(cartId, Instant.now())), updatedCart => Accepted(updatedCart.toSummary)))
+        }
+      case Get =>
+        UIO((Command.ignore, _ => state.toSummary))
+    }
+
+  private def checkedOutShoppingCart[A](
+    cartId: String,
+    state: State,
+    command: Command[A]
+  ): UIO[(persistence.Command[Event], State => A)] =
+    command match {
+      case Get =>
+        UIO((Command.ignore, _ => state.toSummary))
+      case _: AddItem =>
+        UIO((Command.ignore, _ => Rejected(s"Can't add an item to an already checked out $cartId shopping cart")))
+      case _: RemoveItem =>
+        UIO((Command.ignore, _ => Rejected(s"Can't remove an item from an already checked out $cartId shopping cart")))
+      case _: AdjustItemQuantity =>
+        UIO((Command.ignore, _ => Rejected(s"Can't adjust item on an already checked out $cartId shopping cart")))
+      case Checkout =>
+        UIO((Command.ignore, _ => Rejected(s"Can't checkout already checked out $cartId shopping cart")))
+
+    }
+
+}

--- a/examples/src/test/resources/application.conf
+++ b/examples/src/test/resources/application.conf
@@ -1,0 +1,12 @@
+testSys.zio.actors.persistence {
+  plugin = "in-mem-journal"
+  key    = "key1"
+}
+
+// Example postgres configuration
+testSysJDBC.zio.actors.persistence {
+  plugin = "jdbc-journal"
+  url    = "jdbc:postgresql://localhost:5432/postgres"
+  user   = "user"
+  pass   = "pass"
+}

--- a/examples/src/test/scala/zio/actors/examples/persistence/ShoppingCartSpec.scala
+++ b/examples/src/test/scala/zio/actors/examples/persistence/ShoppingCartSpec.scala
@@ -1,0 +1,95 @@
+package zio.actors.examples.persistence
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import zio.{ Cause, Managed, Schedule, UIO, ZIO }
+import zio.actors.{ ActorSystem, Supervisor }
+import zio.clock.Clock.Live
+import zio.duration.Duration
+import zio.test._
+import zio.test.Assertion._
+import ShoppingCart._
+import Deps._
+
+object Deps {
+  val actorSystem: Managed[TestFailure[Throwable], ActorSystem] =
+    Managed.make(
+      ActorSystem("testSys", Some(new File("./src/test/resources/application.conf")))
+        .mapError(e => TestFailure.Runtime(Cause.die(e)))
+    )(_.shutdown.catchAll(_ => UIO.unit))
+
+  val recoverPolicy = Supervisor.retry(Schedule.exponential(Duration(200, TimeUnit.MILLISECONDS)).provide(Live))
+
+}
+
+object ShoppingCartSpec
+    extends DefaultRunnableSpec(
+      suite("The Shopping Cart should")(
+        testM("add item") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart <- as.make("cart1", recoverPolicy, State.empty, ShoppingCart("cart1"))
+              conf <- cart ? AddItem("foo", 42)
+            } yield assert(conf, equalTo(Accepted(Summary(Map("foo" -> 42), checkedOut = false))))
+          }
+        },
+        testM("reject already added item") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart  <- as.make("cart2", recoverPolicy, State.empty, ShoppingCart("cart2"))
+              conf1 <- cart ? AddItem("foo", 42)
+              conf2 <- cart ? AddItem("foo", 13)
+            } yield assert(conf1, isSubtype[Accepted](anything)) && assert(conf2, isSubtype[Rejected](anything))
+          }
+        },
+        testM("remove item") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart  <- as.make("cart3", recoverPolicy, State.empty, ShoppingCart("cart3"))
+              conf1 <- cart ? AddItem("foo", 42)
+              conf2 <- cart ? RemoveItem("foo")
+            } yield assert(conf1, isSubtype[Accepted](anything)) && assert(
+              conf2,
+              equalTo(Accepted(Summary(Map.empty, checkedOut = false)))
+            )
+          }
+        },
+        testM("adjust quantity") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart  <- as.make("cart4", recoverPolicy, State.empty, ShoppingCart("cart4"))
+              conf1 <- cart ? AddItem("foo", 42)
+              conf2 <- cart ? AdjustItemQuantity("foo", 43)
+            } yield assert(conf1, isSubtype[Accepted](anything)) && assert(
+              conf2,
+              equalTo(Accepted(Summary(Map("foo" -> 43), checkedOut = false)))
+            )
+          }
+        },
+        testM("checkout") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart  <- as.make("cart5", recoverPolicy, State.empty, ShoppingCart("cart5"))
+              conf1 <- cart ? AddItem("foo", 42)
+              conf2 <- cart ? Checkout
+            } yield assert(conf1, isSubtype[Accepted](anything)) && assert(
+              conf2,
+              equalTo(Accepted(Summary(Map("foo" -> 42), checkedOut = true)))
+            )
+          }
+        },
+        testM("keep its state") {
+          ZIO.accessM[ActorSystem] { as =>
+            for {
+              cart   <- as.make("cart6", recoverPolicy, State.empty, ShoppingCart("cart6"))
+              conf1  <- cart ? AddItem("foo", 42)
+              _      <- cart.stop
+              cart   <- as.make("cart6", recoverPolicy, State.empty, ShoppingCart("cart6"))
+              status <- cart ? Get
+            } yield assert(conf1, equalTo(Accepted(Summary(Map("foo" -> 42), checkedOut = false)))) &&
+              assert(status, equalTo(Summary(Map("foo" -> 42), checkedOut = false)))
+          }
+        }
+      ).provideManagedShared(actorSystem)
+    )


### PR DESCRIPTION
Hi @softinio @mijicd 

I thought that it would be valuable to have a counterpart of [Akka Samples Project](https://github.com/akka/akka-samples) where we can first rewrite all examples 1:1 to show how the same things can be done in `zio-actors`. Even though almost all of them require Clustering functionality there are two samples that don't: FSM and Persistence.

In this PR I've added a new module for that and [Persistence Shopping Cart Sample](https://github.com/akka/akka-samples/tree/2.6/akka-sample-persistence-scala) rewritten 1:1 in `zio-actors`.

WDYT?