### PR TITLE
Upgraded cats-interop version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val zioActorsPersistenceJDBC = module("zio-actors-persistence-jdbc", "persi
     libraryDependencies ++= Seq(
       "dev.zio"      %% "zio-test"         % zioVersion % "test",
       "dev.zio"      %% "zio-test-sbt"     % zioVersion % "test",
-      "dev.zio"      %% "zio-interop-cats" % "2.0.0.0-RC10",
+      "dev.zio"      %% "zio-interop-cats" % "2.0.0.0-RC11",
       "org.tpolecat" %% "doobie-core"      % "0.8.8",
       "org.tpolecat" %% "doobie-hikari"    % "0.8.8",
       "org.tpolecat" %% "doobie-postgres"  % "0.8.8"


### PR DESCRIPTION
@mijicd @softinio Hi! Last PR for upgrading last ZIO library to fully depend on RC18.