### PR TITLE
Construct Journals via a JournalFactory

### DIFF
--- a/examples/src/main/scala/zio/actors/examples/persistence/ShoppingCart.scala
+++ b/examples/src/main/scala/zio/actors/examples/persistence/ShoppingCart.scala
@@ -74,7 +74,7 @@ object ShoppingCart {
         context: Context
       ): UIO[(persistence.Command[Event], State => A)] =
         if (state.isCheckedOut) checkedOutShoppingCart[A](cartId, state, msg)
-        else openShoppingCard[A](cartId, state, msg)
+        else openShoppingCart[A](cartId, state, msg)
 
       override def sourceEvent(state: State, event: Event): State =
         event match {
@@ -86,7 +86,7 @@ object ShoppingCart {
         }
     }
 
-  private def openShoppingCard[A](
+  private def openShoppingCart[A](
     cartId: String,
     state: State,
     command: Command[A]

--- a/persistence-jdbc/src/main/scala/zio/actors/persistence/jdbc/JDBCJournal.scala
+++ b/persistence-jdbc/src/main/scala/zio/actors/persistence/jdbc/JDBCJournal.scala
@@ -8,7 +8,7 @@ import doobie.implicits._
 import zio.{ IO, Promise, Runtime, Task, UIO, ZIO }
 import zio.actors.ActorSystemUtils
 import zio.actors.persistence.PersistenceId.PersistenceId
-import zio.actors.persistence.journal.Journal
+import zio.actors.persistence.journal.{ Journal, JournalFactory }
 import zio.actors.persistence.jdbc.JDBCConfig.DbConfig
 import zio.blocking.Blocking
 import zio.interop.catz._
@@ -29,7 +29,7 @@ private[actors] final class JDBCJournal[Ev](tnx: Transactor[Task]) extends Journ
 
 }
 
-private[actors] object JDBCJournal {
+object JDBCJournal extends JournalFactory {
 
   private lazy val runtime           = Runtime.default
   private lazy val transactorPromise = runtime.unsafeRun(Promise.make[Exception, HikariTransactor[Task]])

--- a/persistence/src/main/scala/zio/actors/persistence/journal/InMemJournal.scala
+++ b/persistence/src/main/scala/zio/actors/persistence/journal/InMemJournal.scala
@@ -22,7 +22,7 @@ private[actors] final class InMemJournal[Ev](journalRef: Ref[List[JournalRow[Ev]
 
 }
 
-private[actors] object InMemJournal {
+object InMemJournal extends JournalFactory {
 
   private case class JournalRow[Ev](persistenceId: PersistenceId, seqNum: Int, event: Ev)
 

--- a/persistence/src/main/scala/zio/actors/persistence/journal/Journal.scala
+++ b/persistence/src/main/scala/zio/actors/persistence/journal/Journal.scala
@@ -10,3 +10,7 @@ private[actors] trait Journal[Ev] {
   def getEvents(persistenceId: PersistenceId): Task[Seq[Ev]]
 
 }
+
+trait JournalFactory {
+  def getJournal[Ev](actorSystemName: String, configStr: String): Task[Journal[Ev]]
+}

--- a/persistence/src/test/resources/application.conf
+++ b/persistence/src/test/resources/application.conf
@@ -13,3 +13,11 @@ testSystem2.zio.actors.persistence {
 testSystem3.zio.actors.persistence {
   plugin = "corrupt-plugin"
 }
+
+testSystem4.zio.actors.persistence {
+  plugin = "non-existent-object"
+}
+
+testSystem5.zio.actors.persistence {
+  plugin = "incorrect-factory"
+}

--- a/persistence/src/test/resources/datastores.conf
+++ b/persistence/src/test/resources/datastores.conf
@@ -1,0 +1,6 @@
+internals.zio.actors.persistence.datastores {
+  in-mem-journal = "zio.actors.persistence.journal.InMemJournal"
+  jdbc-journal = "zio.actors.persistence.jdbc.JDBCJournal"
+  non-existent-object = "zio.actors.persistence.NonExistent"
+  incorrect-factory = "zio.actors.persistence.IncorrectFactory"
+}

--- a/persistence/src/test/scala/zio/actors/persistence/IncorrectFactory.scala
+++ b/persistence/src/test/scala/zio/actors/persistence/IncorrectFactory.scala
@@ -1,0 +1,3 @@
+package zio.actors.persistence
+
+object IncorrectFactory {}

--- a/persistence/src/test/scala/zio/actors/persistence/PersistenceSpec.scala
+++ b/persistence/src/test/scala/zio/actors/persistence/PersistenceSpec.scala
@@ -77,6 +77,40 @@ object PersistenceSpec extends DefaultRunnableSpec {
                 )
               )
           )
+        },
+        testM("Plugin with a non-existing factory class") {
+          val program = for {
+            as <- ActorSystem("testSystem4", configFile)
+            _  <- as.make("actor1", Supervisor.none, 0, ESCounterHandler)
+          } yield ()
+
+          assertM(program.run)(
+            fails(isSubtype[Throwable](anything)) &&
+              fails(
+                hasField[Throwable, Boolean](
+                  "message",
+                  e => e.toString.contains("non-existent") && e.toString.contains("NonExistent"),
+                  isTrue
+                )
+              )
+          )
+        },
+        testM("Plugin with an incorrect factory") {
+          val program = for {
+            as <- ActorSystem("testSystem5", configFile)
+            _  <- as.make("actor1", Supervisor.none, 0, ESCounterHandler)
+          } yield ()
+
+          assertM(program.run)(
+            fails(isSubtype[Throwable](anything)) &&
+              fails(
+                hasField[Throwable, Boolean](
+                  "message",
+                  _.toString.contains("incorrect-factory"),
+                  isTrue
+                )
+              )
+          )
         }
       )
     )


### PR DESCRIPTION
This makes it clearer which method the companion object has to implement
instead of solely relying on convention and reflection.