### PR TITLE
Run Github actions on release published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on:
     branches: ['*']
   push:
     branches: ['master']
-    tags: ['v*']
+  release:
+    types:
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
When doing a release via the draft release prepared by the release drafter, CI is not triggered to do the release. Adding running github actions on released when published to the list of events.

As we are doing this by type of event matching by take name format I don't think is necessary.

Will test with next release after this PR merged.
